### PR TITLE
dtx: fix fc-list cmd

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -592,7 +592,7 @@
 %
 % 另外，用户也可以通过命令
 % \begin{shell}
-% $ fs-list :lang=zh > zhfonts.txt
+% $ fc-list :lang=zh file family style > zhfonts.txt
 % \end{shell}
 % 得到系统中现有的中文字体列表，并相应替换上述配置。
 %


### PR DESCRIPTION
- There was a terrible typo: fs-list should be fc-list .
- fc-list does not include file path in output on Windows 8.
  We now explicitly ask for it.