### PR TITLE
dtx: not mention pdfpagelabels (hyperref default)

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1259,7 +1259,6 @@
   breaklinks=true,
   colorlinks=false,
   plainpages=false,
-  pdfpagelabels,
   pdfborder=0 0 0}
 %    \end{macrocode}
 %
@@ -3160,7 +3159,6 @@
   breaklinks=true,
   linkcolor=blue,
   plainpages=false,
-  pdfpagelabels,
   pdfborder=0 0 0}
 \RequirePackage{url}
 \RequirePackage{indentfirst}


### PR DESCRIPTION
This helps to eliminate one hyperref Warning.
cf. http://www.newsmth.net/nForum/#!article/TeX/323639?p=1#a2