### PR TITLE
\section 等标题的定义中 BEFORESKIP 不使用负号。

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1983,7 +1983,7 @@
 % 子！}
 %    \begin{macrocode}
 \renewcommand\section{\@startsection {section}{1}{\z@}%
-                     {\ifthu@bachelor -25bp\else -24bp\fi\@plus -1ex \@minus -.2ex}%
+                     {\ifthu@bachelor 25bp\else 24bp\fi\@plus 1ex \@minus .2ex}%
                      {\ifthu@bachelor 12bp\else 6bp\fi \@plus .2ex}%
                      {\csname thu@title@font\endcsname\heiti\sihao[1.429]}}
 %    \end{macrocode}
@@ -1996,7 +1996,7 @@
 % \changes{v4.4}{2008/06/04}{调整段前距为 -12bp 而不是原来的 -16bp。}
 %    \begin{macrocode}
 \renewcommand\subsection{\@startsection{subsection}{2}{\z@}%
-                        {\ifthu@bachelor -12bp\else -16bp\fi\@plus -1ex \@minus -.2ex}%
+                        {\ifthu@bachelor 12bp\else 16bp\fi\@plus 1ex \@minus .2ex}%
                         {6bp \@plus .2ex}%
                         {\csname thu@title@font\endcsname\heiti\ifthu@bachelor\xiaosi[1.667]\else\banxiaosi[1.538]\fi}}
 %    \end{macrocode}
@@ -2008,7 +2008,7 @@
 % \changes{v4.4}{2008/06/04}{调整段前距为 -12bp 而不是原来的 -16bp。}
 %    \begin{macrocode}
 \renewcommand\subsubsection{\@startsection{subsubsection}{3}{\z@}%
-                           {\ifthu@bachelor -12bp\else -16bp\fi\@plus -1ex \@minus -.2ex}%
+                           {\ifthu@bachelor 12bp\else 16bp\fi\@plus 1ex \@minus .2ex}%
                            {6bp \@plus .2ex}%
                            {\csname thu@title@font\endcsname\heiti\xiaosi[1.667]}}
 %</cls>
@@ -3264,27 +3264,11 @@ leftmargin=10mm,labelsep=!,before*=\xiaosi[1.26]}
       \thesubsubsection\quad
       \fi
       ##1}}}
-\renewcommand\section{\@startsection{section}{1}{\z@}%
-                                    {-3.5ex \@plus -1ex \@minus -.2ex}%
-                                    {2.3ex \@plus.2ex}%
-                                    {\normalfont\Large\bfseries}}
-
-\renewcommand\subsection{\@startsection{subsection}{2}{\z@}%
-                                       {-3.25ex\@plus -1ex \@minus -.2ex}%
-                                       {1.5ex \@plus .2ex}%
-                                       {\normalfont\large\bfseries}}
-\renewcommand\subsubsection{\@startsection{subsubsection}{3}{\z@}%
-                                          {-3.25ex\@plus -1ex \@minus -.2ex}%
-                                          {1.5ex \@plus .2ex}%
-                                          {\normalfont\normalsize\bfseries}}
-\renewcommand\paragraph{\@startsection{paragraph}{4}{\z@}%
-                                      {3.25ex \@plus1ex \@minus.2ex}%
-                                      {-1em}%
-                                      {\normalfont\normalsize\bfseries}}
-\renewcommand\subparagraph{\@startsection{subparagraph}{5}{\parindent}%
-                                         {3.25ex \@plus1ex \@minus .2ex}%
-                                         {-1em}%
-                                         {\normalfont\normalsize\bfseries}}
+\ifdefined \ctexset
+  \ctexset{section/format=\Large\bfseries}
+\else
+  \CTEXsetup[format=\Large\bfseries]{section}
+\fi
 \pagestyle{empty}
 \MakeShortVerb{\|}
 \def\pkg#1{\texttt{#1}}


### PR DESCRIPTION
在 LaTeX 的标准定义中，`\@startsection` 的第四个参数 `BEFORESKIP` 的符号用于确定标题后的第一段是否有段首缩进。如果是负号，则抑制段首缩进，符合英文的排版习惯。我们这里按照中文的排版习惯，应该有缩进，也就不应该用负号。可参见 [SMTH] 上的讨论。

这么做也是要兼容即将发布的 `ctex` v2.2。因为 `ctex` v2.2 改变了 `\@startsection` 的行为，它的第四和第五个参数的符号不再有特殊意义，对应的功能由新的 `bool` 选项 `afterindent` 和 `runin` 来提供。参见 CTeX-org/ctex-kit#208。

[SMTH]: http://www.newsmth.net/bbstcon.php?board=TeX&gid=324095