### PR TITLE
added option to use custom fontset

### DIFF
--- a/ctex-fontset-custom.def
+++ b/ctex-fontset-custom.def
@@ -1,0 +1,45 @@
+%%
+%% This file is modified from  `ctex-fontset-adobe.def` provided by ctex.
+%%
+%% The original source files were:
+%%
+%% ctex.dtx  (with options: `fontset,custom')
+%% 
+%%     Copyright (C) 2003--2015
+%%     CTEX.ORG and any individual authors listed in the documentation.
+%% ------------------------------------------------------------------------------
+%% 
+%%     This work may be distributed and/or modified under the
+%%     conditions of the LaTeX Project Public License, either
+%%     version 1.3c of this license or (at your option) any later
+%%     version. This version of this license is in
+%%        http://www.latex-project.org/lppl/lppl-1-3c.txt
+%%     and the latest version of this license is in
+%%        http://www.latex-project.org/lppl.txt
+%%     and version 1.3 or later is part of all distributions of
+%%     LaTeX version 2005/12/01 or later.
+%% 
+%%     This work has the LPPL maintenance status `maintained'.
+%%  
+%%     The Current Maintainers of this work are Leo Liu, Qing Lee and Liam Huang.
+%% 
+%% ------------------------------------------------------------------------------
+%% 
+\ProvidesExplFile{ctex-fontset-custom.def}
+  {\ExplFileDate}{2.3}{\ExplFileDescription}
+
+\setCJKmainfont
+  [
+	  BoldFont = 黑体 ,
+	ItalicFont = 楷体
+  ] { 宋体 }
+\setCJKsansfont { 黑体 }
+\setCJKmonofont { 楷体 }
+\setCJKfamilyfont { zhsong } { 宋体 }
+\setCJKfamilyfont { zhhei }  { 黑体 }
+\setCJKfamilyfont { zhfs }   { 仿宋 }
+\setCJKfamilyfont { zhkai }  { 楷体 }
+\NewDocumentCommand \songti   { } { \CJKfamily { zhsong } }
+\NewDocumentCommand \heiti    { } { \CJKfamily { zhhei } }
+\NewDocumentCommand \fangsong { } { \CJKfamily { zhfs } }
+\NewDocumentCommand \kaishu   { } { \CJKfamily { zhkai } }

--- a/main.tex
+++ b/main.tex
@@ -7,7 +7,7 @@
 %   arial,                                    % 可选，基本不用
 %   arialtoc,                                 % 可选，基本不用
 %   arialtitle                                % 可选，基本不用
-%   fontset=custom                            % 可选, 用于自定义自体
+%   fontset=custom                            % 可选, 用于自定义字体
 
 % 所有其它可能用到的包都统一放到这里了，可以根据自己的实际添加或者删除。
 \usepackage{thuthesis}

--- a/main.tex
+++ b/main.tex
@@ -7,6 +7,7 @@
 %   arial,                                    % 可选，基本不用
 %   arialtoc,                                 % 可选，基本不用
 %   arialtitle                                % 可选，基本不用
+%   fontset=custom                            % 可选, 用于自定义自体
 
 % 所有其它可能用到的包都统一放到这里了，可以根据自己的实际添加或者删除。
 \usepackage{thuthesis}


### PR DESCRIPTION
发现字体问题现在还是比较麻烦的，在使用 ctex 之后，用户失去了自定义字体的能力。
在 Mac 和 Linux 下，由于 ctex 2.2 默认使用 fandol 字体，很多字符缺失（比如我的名字）。

所以增加了一个 `fontset=custom` 选项，打开时就根据 `ctex-fontset-custom.def` 来定义字体。
必要的时候，可以让用户「找个windows拷贝个宋体」。
