### PR TITLE
fix a typo in the example of exercise

### DIFF
--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -476,7 +476,7 @@ V_j & = v_j, & \qquad X_j & = x_j,
 \end{example}
 
 \begin{exercise}
-  清列出 Andrew S. Tanenbaum 和 W. Richard Stevens 的所有著作。
+  请列出 Andrew S. Tanenbaum 和 W. Richard Stevens 的所有著作。
 \end{exercise}
 
 \begin{conjecture} \textit{Poincare Conjecture} If in a closed three-dimensional


### PR DESCRIPTION
In the example of exercise, "请列出" is written as "清列出".