### PR TITLE
fix bst

### DIFF
--- a/thuthesis-author-year.bst
+++ b/thuthesis-author-year.bst
@@ -1721,8 +1721,6 @@ FUNCTION {begin.bib}
   if$
   "\begin{thebibliography}{" number.label int.to.str$ * "}" *
   write$ newline$
-  "\bibpunct{(}{)}{;}{a}{,}{,}"
-  write$ newline$
   "\providecommand{\natexlab}[1]{#1}"
   write$ newline$
   "\providecommand{\url}[1]{\texttt{#1}}"

--- a/thuthesis-numerical.bst
+++ b/thuthesis-numerical.bst
@@ -1580,8 +1580,6 @@ FUNCTION {begin.bib}
   if$
   "\begin{thebibliography}{" number.label int.to.str$ * "}" *
   write$ newline$
-  "\bibpunct{[}{]}{,}{s}{,}{,}"
-  write$ newline$
   "\providecommand{\natexlab}[1]{#1}"
   write$ newline$
   "\providecommand{\url}[1]{\texttt{#1}}"


### PR DESCRIPTION
原来的 natbib 有个问题：`\setcitestyle` 会影响 `\bibliography` 的 label：比如前面用了 `\setcitestyle{authoryear}`，后面再用 `\bibliographystyle{numerical}` 就导致参考文献表没有数字标签了。

所以我在 `\begin{thebibliography}` 后加了 `\bibpunct{(}{)}{;}{a}{,}{,}` 来修正上述问题，但是这么做会导致参考文献表的续行悬挂缩进不对。虽然 thuthesis 重定义了 `\thebibliography`，我不知道对这对thuthesis 有什么影响，但我还是建议删掉。