### PR TITLE
Enhance cross platform compatibility for font selection

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -1,4 +1,4 @@
-\documentclass[type=bachelor,fontset=windowsold]{thuthesis}
+\documentclass[type=master]{thuthesis}
 % 选项：
 %   type=[bachelor|master|doctor|postdoctor], % 必选
 %   secret,                                   % 可选

--- a/shuji.tex
+++ b/shuji.tex
@@ -1,8 +1,6 @@
 \documentclass[type=master]{thuthesis}
 
-\ifxetex
-  \setCJKfamilyfont{zhfs}[RawFeature={vertical:}]{FangSong}
-\else % for latex/pdflatex
+\ifxetex\relax\else % for latex/pdflatex
   \usepackage{CJKvert}
 \fi
 

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1165,6 +1165,12 @@
 \DeclareBoolOption{arialtitle}
 %    \end{macrocode}
 %
+% 在 Windows Vista 或之后系统下时，默认使用微软雅黑，这可能会导致审查不合格。
+% 下面设置默认不使用微软雅黑，同时保持跨平台兼容性。
+%    \begin{macrocode}
+\IfFileExists{/dev/null}{}{\PassOptionsToClass{fontset=windowsold}{ctexbook}}
+%    \end{macrocode}
+%
 % \option{raggedbottom} 选项（默认打开）
 % \changes{v4.8}{2013/03/05}{增加 noraggedbottom 选项。}
 % \changes{v5.0.0}{2015/12/13}{norggedbottom 选项修改为 raggedbottom。}
@@ -3296,7 +3302,9 @@
 %    \begin{macrocode}
 %<*cls>
 \NewDocumentCommand{\shuji}{O{\thu@ctitle} O{\thu@cauthor}}{%
-  \newpage\thispagestyle{empty}\fangsong\xiaosan\ziju{0.4}%
+  \newpage\thispagestyle{empty}%
+  \fangsong\ifxetex\addCJKfontfeatures*{RawFeature={vertical:}}\fi
+  \xiaosan\ziju{0.4}%
   \noindent\hfill\rotatebox[origin=lt]{-90}{\makebox[\textheight]{#1\hfill#2}}}
 %</cls>
 %    \end{macrocode}


### PR DESCRIPTION
1. 解决了微软雅黑（ #271 ）的问题，默认情况下可以跨平台编译，并且允许用户自己选择；
2. 原来的 `\setCJKfamilyfont{zhfs}` 在其他平台下会出问题，使用 `\addCJKfontfeatures` 解决。