### PR TITLE
移除参考文献的 doi

### DIFF
--- a/thuthesis-author-year.bst
+++ b/thuthesis-author-year.bst
@@ -436,31 +436,8 @@ FUNCTION {format.url}
   if$
 }
 
-FUNCTION {is.doi.in.url}
-{ url empty$
-    { #0 }
-    { doi text.length$ 'stringlength :=
-      url text.length$ 'charptr :=
-        { url charptr stringlength substring$ doi = not
-          charptr #0 >
-          and
-        }
-        { charptr #1 - 'charptr := }
-      while$
-      charptr
-    }
-  if$
-}
-
 FUNCTION {format.doi}
-{ doi empty$
-    { "" }
-    { is.doi.in.url
-        { "" }
-        { new.block "\doi{" doi * "}" * }
-      if$
-    }
-  if$
+{ ""
 }
 
 FUNCTION {format.title}

--- a/thuthesis-numeric.bst
+++ b/thuthesis-numeric.bst
@@ -435,31 +435,8 @@ FUNCTION {format.url}
   if$
 }
 
-FUNCTION {is.doi.in.url}
-{ url empty$
-    { #0 }
-    { doi text.length$ 'stringlength :=
-      url text.length$ 'charptr :=
-        { url charptr stringlength substring$ doi = not
-          charptr #0 >
-          and
-        }
-        { charptr #1 - 'charptr := }
-      while$
-      charptr
-    }
-  if$
-}
-
 FUNCTION {format.doi}
-{ doi empty$
-    { "" }
-    { is.doi.in.url
-        { "" }
-        { new.block "\doi{" doi * "}" * }
-      if$
-    }
-  if$
+{ ""
 }
 
 FUNCTION {format.title}


### PR DESCRIPTION
我刚刚才注意到清华的参考文献没有 doi 项，不好意思之前更新 bst 的时候不小心把 doi 加进去了，所以另发一个 PR fix 这个问题