### PR TITLE
调整博士模板中论文首页“联合导师”的字距

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -2608,14 +2608,12 @@
                 \thu@put@title{\thu@assosuper@title} & \thu@title@sep
                 & {\ziju{0.6875}\thu@cassosupervisor}\\
               \fi
-              \ifthu@master
-                \ifx\thu@ccosupervisor\@empty\else
+              \ifx\thu@ccosupervisor\@empty\else
+                \ifthu@master
                   \hfill\makebox[0pt][r]{\thu@cosuper@title} & \thu@title@sep
                   & {\ziju{0.6875}\thu@ccosupervisor}\\
                 \fi
-              \fi
-              \ifthu@doctor
-                \ifx\thu@ccosupervisor\@empty\else
+                \ifthu@doctor
                   \thu@put@title{\thu@cosuper@title} & \thu@title@sep
                   & {\ziju{0.6875}\thu@ccosupervisor}\\
                 \fi

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -2608,9 +2608,17 @@
                 \thu@put@title{\thu@assosuper@title} & \thu@title@sep
                 & {\ziju{0.6875}\thu@cassosupervisor}\\
               \fi
-              \ifx\thu@ccosupervisor\@empty\else
-                \hfill\makebox[0pt][r]{\thu@cosuper@title} & \thu@title@sep
-                & {\ziju{0.6875}\thu@ccosupervisor}\\
+              \ifthu@master
+                \ifx\thu@ccosupervisor\@empty\else
+                  \hfill\makebox[0pt][r]{\thu@cosuper@title} & \thu@title@sep
+                  & {\ziju{0.6875}\thu@ccosupervisor}\\
+                \fi
+              \fi
+              \ifthu@doctor
+                \ifx\thu@ccosupervisor\@empty\else
+                  \thu@put@title{\thu@cosuper@title} & \thu@title@sep
+                  & {\ziju{0.6875}\thu@ccosupervisor}\\
+                \fi
               \fi
             \end{tabular}
         \end{center}}}


### PR DESCRIPTION
现在的模板里面博士和硕士的“cosupervisor”用的是不同的中文。博士模板正好四个字不存在硕士模板中“联合指导教师”过长的问题。不太确定学校的论文模板对联合导师的字距要求，但是感觉和上面的对齐比较好看一点。