### PR TITLE
Fix dashes in bibliography and citations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ dist
 *.hd
 *.fdb_latexmk
 *.fls
+*.synctex
+*.synctex(busy)
+*.synctex.gz
+*.synctex.gz(busy)
 *.xdv
 dtx-style.sty
 thuthesis.cls

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Compiling method: latexmk/xelatex/pdflatex
 METHOD = latexmk
 # Set opts for latexmk if you use it
-LATEXMKOPTS = -xelatex -halt-on-error -interaction=nonstopmode
+LATEXMKOPTS = -xelatex -file-line-error -halt-on-error -interaction=nonstopmode
 # Basename of thesis
 THESISMAIN = main
 # Basename of shuji

--- a/latexmkrc
+++ b/latexmkrc
@@ -1,5 +1,6 @@
 # vim: set ft=perl:
-$clean_ext = 'thm glo gls bbl hd loe xdv';
+$xdvipdfmx="xdvipdfmx -E -o %D %O %S";
+$clean_ext = 'thm glo gls bbl hd loe synctex.gz xdv';
 $makeindex = 'makeindex -s gind.ist %O -o %D %S';
 add_cus_dep('glo', 'gls', 0, 'makeglo2gls');
 sub makeglo2gls {

--- a/thuthesis-author-year.bst
+++ b/thuthesis-author-year.bst
@@ -1,12 +1,12 @@
 %%
-%% This is file `gbt-7714-2015-author-year.bst',
+%% This is file `gbt7714-plain.bst',
 %% generated with the docstrip utility.
 %%
 %% The original source files were:
 %%
-%% gbt-7714-2015.dtx  (with options: `authoryear')
+%% gbt7714.dtx  (with options: `authoryear')
 %% 
-%% Copyright (C) 2016-2017 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016-2018 by Zeping Lee <zepinglee AT gmail.com>
 %% 
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either
@@ -25,23 +25,16 @@ ENTRY
   { address
     author
     booktitle
-    chapter
     date
     doi
-    eid
     edition
     editor
-    howpublished
     institution
-    isbn
-    issn
     journal
     key
     language
     mark
-    media
-    month
-    note
+    medium
     number
     organization
     pages
@@ -51,7 +44,6 @@ ENTRY
     series
     title
     translator
-    type
     url
     urldate
     volume
@@ -62,7 +54,7 @@ ENTRY
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block after.slash }
 
-INTEGERS { lang.zh lang.ja lang.en lang.ru }
+INTEGERS { lang.zh lang.ja lang.en lang.ru lang.other }
 
 INTEGERS { charptr stringlength }
 
@@ -72,10 +64,11 @@ FUNCTION {init.state.consts}
   #2 'after.sentence :=
   #3 'after.block :=
   #4 'after.slash :=
-  #2 'lang.zh :=
-  #3 'lang.ja :=
-  #0 'lang.en :=
-  #1 'lang.ru :=
+  #3 'lang.zh :=
+  #4 'lang.ja :=
+  #1 'lang.en :=
+  #2 'lang.ru :=
+  #0 'lang.other :=
 }
 
 STRINGS { s t }
@@ -291,13 +284,17 @@ INTEGERS { ascii }
 
 FUNCTION {get.char.lang}
 { chr.to.int$ 'ascii :=
-  ascii #227 > ascii #234 < and
-    { lang.zh }
-    { ascii #227 =
-        { lang.ja }
-        { ascii #207 > ascii #212 < and
-            { lang.ru }
-            { lang.en }
+  ascii #64 > ascii #91 < and ascii #96 > ascii #123 < and or
+    { lang.en }
+    { ascii #227 > ascii #234 < and
+        { lang.zh }
+        { ascii #227 =
+            { lang.ja }
+            { ascii #207 > ascii #212 < and
+                { lang.ru }
+                { lang.en }
+              if$
+            }
           if$
         }
       if$
@@ -305,21 +302,21 @@ FUNCTION {get.char.lang}
   if$
 }
 
-INTEGERS { char.lang lang }
+INTEGERS { char.lang tmp.lang }
 
 STRINGS { tmp.str }
 
 FUNCTION {get.str.lang}
 { 'tmp.str :=
-  lang.en 'lang :=
+  lang.other 'tmp.lang :=
   tmp.str empty$
     { "Empty string!" warning$ }
     { #1 'charptr :=
       tmp.str text.length$ #1 + 'stringlength :=
         { charptr stringlength < }
         { tmp.str charptr #1 substring$ get.char.lang 'char.lang :=
-          char.lang lang >
-            { char.lang 'lang := }
+          char.lang tmp.lang >
+            { char.lang 'tmp.lang := }
             'skip$
           if$
 
@@ -335,7 +332,7 @@ FUNCTION {get.str.lang}
       while$
     }
   if$
-  lang
+  tmp.lang
 }
 
 FUNCTION {is.in.chinese}
@@ -356,35 +353,33 @@ FUNCTION {format.anonymous}
   if$
 }
 
-INTEGERS { nameptr namesleft numnames name.lang}
+INTEGERS { nameptr namesleft numnames name.lang }
 
 FUNCTION {format.names}
 { 's :=
   #1 'nameptr :=
   s num.names$ 'numnames :=
   numnames 'namesleft :=
-    { namesleft #0 > nameptr #4 < and }
+    { namesleft #0 > }
     { s nameptr "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
-      t get.str.lang 'name.lang :=
-      name.lang lang.en =
-        { t #1 "{vv~}{ll}{ f{~}}{, jj}" format.name$ 't := }
-        { t #1 "{ll}{ff}" format.name$ 't := }
-      if$
-      nameptr #1 >
-        { namesleft #1 >
-            { ", " * t * }
-            { t "others" =
-                { ", " * format.et.al * }
-                { ", " * t * }
+      nameptr #4 =
+        { format.et.al
+          #1 'namesleft :=
+        }
+        { t "others" =
+            { format.et.al }
+            { t get.str.lang 'name.lang :=
+              name.lang lang.en =
+                { t #1 "{vv~}{ll}{ f{~}}{, jj}" format.name$ }
+                { t #1 "{ll}{ff}" format.name$ }
               if$
             }
           if$
-          nameptr #3 = namesleft #1 > and
-            { ", " * format.et.al * }
-            'skip$
-          if$
         }
-        't
+      if$
+      nameptr #1 >
+        { ", " swap$ * * }
+        'skip$
       if$
       nameptr #1 + 'nameptr :=
       namesleft #1 - 'namesleft :=
@@ -454,8 +449,8 @@ FUNCTION {set.mark}
         { pop$ mark 'entry.mark := }
         { 'entry.mark := }
       if$
-      media empty$ not
-        { entry.mark "/" * media * 'entry.mark := }
+      medium empty$ not
+        { entry.mark "/" * medium * 'entry.mark := }
         { url empty$ not
             { entry.mark "/OL" * 'entry.mark := }
             'skip$
@@ -535,7 +530,9 @@ FUNCTION {make.full.names}
   type$ "inbook" =
   or
     'author.editor.full
-    { type$ "proceedings" =
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
         'editor.full
         'author.full
       if$
@@ -559,23 +556,15 @@ FUNCTION {output.bibitem}
   before.all 'output.state :=
 }
 
-
-FUNCTION {n.dashify}
+FUNCTION {hyphenate}
 { 't :=
   ""
     { t empty$ not }
     { t #1 #1 substring$ "-" =
-        { t #1 #2 substring$ "--" = not
-            { "--" *
-              t #2 global.max$ substring$ 't :=
-            }
-            {   { t #1 #1 substring$ "-" = }
-                { "-" *
-                  t #2 global.max$ substring$ 't :=
-                }
-              while$
-            }
-          if$
+        { "-" *
+            { t #1 #1 substring$ "-" = }
+            { t #2 global.max$ substring$ 't := }
+          while$
         }
         { t #1 #1 substring$ *
           t #2 global.max$ substring$ 't :=
@@ -921,7 +910,7 @@ FUNCTION {format.address.publisher}
 FUNCTION {format.pages}
 { pages empty$
     { "" }
-    { pages n.dashify }
+    { pages hyphenate }
   if$
 }
 
@@ -985,9 +974,9 @@ FUNCTION {format.in.ed.booktitle}
 }
 
 FUNCTION {empty.misc.check}
-{ author empty$ title empty$ howpublished empty$
-  month empty$ year empty$ note empty$
-  and and and and and
+{ author empty$ title empty$
+  year empty$
+  and and
   key empty$ not and
     { "all relevant fields are empty in " cite$ * warning$ }
     'skip$
@@ -1203,17 +1192,20 @@ FUNCTION {online}
 
 FUNCTION {misc}
 { journal empty$ not
-    { article.in.journal }
+    'article.in.journal
     { booktitle empty$ not
-        { incollection }
+        'incollection
         { url empty$ not
-            { online }
-            { monograph }
+            'online
+            { "Z" set.mark
+              monograph
+            }
           if$
         }
       if$
     }
   if$
+  empty.misc.check
 }
 
 FUNCTION {archive}
@@ -1227,7 +1219,8 @@ FUNCTION {book} { monograph }
 
 FUNCTION {collection}
 { "G" set.mark
-  monograph }
+  monograph
+}
 
 FUNCTION {database}
 { "DB" set.mark
@@ -1281,7 +1274,7 @@ FUNCTION {proceedings}
   monograph
 }
 
-FUNCTION {program}
+FUNCTION {software}
 { "CP" set.mark
   misc
 }
@@ -1370,7 +1363,7 @@ EXECUTE {init.state.consts}
 FUNCTION {set.entry.lang}
 { language empty$
     { author field.or.null title field.or.null * get.str.lang }
-    { language "english" =
+    { language "english" = language "american" = or language "british" = or
         { lang.en }
         { language "chinese" =
             { lang.zh }
@@ -1378,7 +1371,7 @@ FUNCTION {set.entry.lang}
                 { lang.ja }
                 { language "russian" =
                     { lang.ru }
-                    { lang.en }
+                    { lang.other }
                   if$
                 }
               if$
@@ -1481,10 +1474,10 @@ FUNCTION {calc.short.authors}
 { type$ "book" =
   type$ "inbook" =
   or
-  type$ "collection" =
-  or
     'author.editor.key.label
-    { type$ "proceedings" =
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
         { editor empty$ not
             'editor.key.organization.label
             'author.key.organization.label
@@ -1502,7 +1495,7 @@ FUNCTION {calc.label}
   short.list
   "("
   *
-  format.year extract.before.dash duplicate$ empty$
+  format.year duplicate$ empty$
   short.list key field.or.null = or
      { pop$ "" }
      'skip$
@@ -1512,20 +1505,15 @@ FUNCTION {calc.label}
 }
 
 FUNCTION {sort.language.label}
-{ lang lang.zh =
-    { "a   "
-      pinyin empty$
-        'skip$
-        { pinyin * "   " * }
-      if$
-    }
-    { lang lang.ja =
-        { "b   " }
-        { lang lang.en =
-            { "c   " }
-            { lang lang.ru =
-                { "d   " }
-                { "e   " }
+{ entry.lang lang.zh =
+    { "a zh " }
+    { entry.lang lang.ja =
+        { "b ja " }
+        { entry.lang lang.en =
+            { "c en " }
+            { entry.lang lang.ru =
+                { "d ru " }
+                { "e other " }
               if$
             }
           if$
@@ -1538,7 +1526,7 @@ FUNCTION {sort.language.label}
 FUNCTION {sort.format.names}
 { 's :=
   #1 'nameptr :=
-  sort.language.label
+  ""
   s num.names$ 'numnames :=
   numnames 'namesleft :=
     { namesleft #0 > }
@@ -1576,65 +1564,77 @@ FUNCTION {sort.format.title}
   #1 global.max$ substring$
 }
 
-FUNCTION {author.sort}
-{ author empty$
-    { key empty$
-        { format.anonymous }
-        { key sortify }
+FUNCTION {key.or.pinyin}
+{ key empty$
+    { pinyin empty$
+        { "" }
+        { pinyin }
       if$
     }
-    { author sort.format.names }
+    { key }
+  if$
+}
+
+FUNCTION {anonymous.sort}
+{ is.in.chinese
+    { "yi4 ming2" }
+    { "anon" }
+  if$
+}
+
+FUNCTION {author.sort}
+{ key.or.pinyin empty$
+    { author empty$
+        { anonymous.sort }
+        { author sort.format.names }
+      if$
+    }
+    { key.or.pinyin sortify }
   if$
 }
 
 FUNCTION {author.editor.sort}
-{ author empty$
+{ key.or.pinyin empty$
+    { author empty$
+        { editor empty$
+            { anonymous.sort }
+            { editor sort.format.names }
+          if$
+        }
+        { author sort.format.names }
+      if$
+    }
+    { key.or.pinyin sortify }
+  if$
+}
+
+FUNCTION {author.organization.sort}
+{ key.or.pinyin empty$
+    { author empty$
+        { organization empty$
+            { anonymous.sort }
+            { "The " #4 organization chop.word sortify }
+          if$
+        }
+        { author sort.format.names }
+      if$
+    }
+    { key.or.pinyin sortify }
+  if$
+}
+
+FUNCTION {editor.organization.sort}
+{ key.or.pinyin empty$
     { editor empty$
-        { key empty$
-            { "to sort, need author, editor, or key in " cite$ * warning$
-              ""
-            }
-            { key sortify }
+        { organization empty$
+            { anonymous.sort }
+            { "The " #4 organization chop.word sortify }
           if$
         }
         { editor sort.format.names }
       if$
     }
-    { author sort.format.names }
-  if$
-}
-
-FUNCTION {author.organization.sort}
-{ author empty$
-    { organization empty$
-        { key empty$
-            { "to sort, need author, organization, or key in " cite$ * warning$
-              ""
-            }
-            { key sortify }
-          if$
-        }
-        { "The " #4 organization chop.word sortify }
-      if$
-    }
-    { author sort.format.names }
-  if$
-}
-
-FUNCTION {editor.organization.sort}
-{ editor empty$
-    { organization empty$
-        { key empty$
-            { "to sort, need editor, organization, or key in " cite$ * warning$
-              ""
-            }
-            { key sortify }
-          if$
-        }
-        { "The " #4 organization chop.word sortify }
-      if$
-    }
-    { editor sort.format.names }
+    { key.or.pinyin sortify }
   if$
 }
 
@@ -1644,20 +1644,20 @@ FUNCTION {presort}
   label sortify
   "    "
   *
+  sort.language.label
   type$ "book" =
   type$ "inbook" =
   or
     'author.editor.sort
-    { type$ "proceedings" =
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
         'editor.organization.sort
-        { type$ "manual" =
-            'author.organization.sort
-            'author.sort
-          if$
-        }
+        'author.sort
       if$
     }
   if$
+  *
   "    "
   *
   year field.or.null sortify

--- a/thuthesis-numeric.bst
+++ b/thuthesis-numeric.bst
@@ -1,12 +1,12 @@
 %%
-%% This is file `gbt-7714-2015-numerical.bst',
+%% This is file `gbt7714-unsrt.bst',
 %% generated with the docstrip utility.
 %%
 %% The original source files were:
 %%
-%% gbt-7714-2015.dtx  (with options: `numerical')
+%% gbt7714.dtx  (with options: `numerical')
 %% 
-%% Copyright (C) 2016-2017 by Zeping Lee <zepinglee AT gmail.com>
+%% Copyright (C) 2016-2018 by Zeping Lee <zepinglee AT gmail.com>
 %% 
 %% This file may be distributed and/or modified under the
 %% conditions of the LaTeX Project Public License, either
@@ -25,32 +25,25 @@ ENTRY
   { address
     author
     booktitle
-    chapter
     date
     doi
-    eid
     edition
     editor
-    howpublished
     institution
-    isbn
-    issn
     journal
     key
     language
     mark
-    media
-    month
-    note
+    medium
     number
     organization
     pages
+    pinyin
     publisher
     school
     series
     title
     translator
-    type
     url
     urldate
     volume
@@ -61,7 +54,7 @@ ENTRY
 
 INTEGERS { output.state before.all mid.sentence after.sentence after.block after.slash }
 
-INTEGERS { lang.zh lang.ja lang.en lang.ru }
+INTEGERS { lang.zh lang.ja lang.en lang.ru lang.other }
 
 INTEGERS { charptr stringlength }
 
@@ -71,10 +64,11 @@ FUNCTION {init.state.consts}
   #2 'after.sentence :=
   #3 'after.block :=
   #4 'after.slash :=
-  #2 'lang.zh :=
-  #3 'lang.ja :=
-  #0 'lang.en :=
-  #1 'lang.ru :=
+  #3 'lang.zh :=
+  #4 'lang.ja :=
+  #1 'lang.en :=
+  #2 'lang.ru :=
+  #0 'lang.other :=
 }
 
 STRINGS { s t }
@@ -290,13 +284,17 @@ INTEGERS { ascii }
 
 FUNCTION {get.char.lang}
 { chr.to.int$ 'ascii :=
-  ascii #227 > ascii #234 < and
-    { lang.zh }
-    { ascii #227 =
-        { lang.ja }
-        { ascii #207 > ascii #212 < and
-            { lang.ru }
-            { lang.en }
+  ascii #64 > ascii #91 < and ascii #96 > ascii #123 < and or
+    { lang.en }
+    { ascii #227 > ascii #234 < and
+        { lang.zh }
+        { ascii #227 =
+            { lang.ja }
+            { ascii #207 > ascii #212 < and
+                { lang.ru }
+                { lang.en }
+              if$
+            }
           if$
         }
       if$
@@ -304,21 +302,21 @@ FUNCTION {get.char.lang}
   if$
 }
 
-INTEGERS { char.lang lang }
+INTEGERS { char.lang tmp.lang }
 
 STRINGS { tmp.str }
 
 FUNCTION {get.str.lang}
 { 'tmp.str :=
-  lang.en 'lang :=
+  lang.other 'tmp.lang :=
   tmp.str empty$
     { "Empty string!" warning$ }
     { #1 'charptr :=
       tmp.str text.length$ #1 + 'stringlength :=
         { charptr stringlength < }
         { tmp.str charptr #1 substring$ get.char.lang 'char.lang :=
-          char.lang lang >
-            { char.lang 'lang := }
+          char.lang tmp.lang >
+            { char.lang 'tmp.lang := }
             'skip$
           if$
 
@@ -334,7 +332,7 @@ FUNCTION {get.str.lang}
       while$
     }
   if$
-  lang
+  tmp.lang
 }
 
 FUNCTION {is.in.chinese}
@@ -355,35 +353,33 @@ FUNCTION {format.anonymous}
   if$
 }
 
-INTEGERS { nameptr namesleft numnames name.lang}
+INTEGERS { nameptr namesleft numnames name.lang }
 
 FUNCTION {format.names}
 { 's :=
   #1 'nameptr :=
   s num.names$ 'numnames :=
   numnames 'namesleft :=
-    { namesleft #0 > nameptr #4 < and }
+    { namesleft #0 > }
     { s nameptr "{vv~}{ll}{, jj}{, ff}" format.name$ 't :=
-      t get.str.lang 'name.lang :=
-      name.lang lang.en =
-        { t #1 "{vv~}{ll}{ f{~}}{, jj}" format.name$ 't := }
-        { t #1 "{ll}{ff}" format.name$ 't := }
-      if$
-      nameptr #1 >
-        { namesleft #1 >
-            { ", " * t * }
-            { t "others" =
-                { ", " * format.et.al * }
-                { ", " * t * }
+      nameptr #4 =
+        { format.et.al
+          #1 'namesleft :=
+        }
+        { t "others" =
+            { format.et.al }
+            { t get.str.lang 'name.lang :=
+              name.lang lang.en =
+                { t #1 "{vv~}{ll}{ f{~}}{, jj}" format.name$ }
+                { t #1 "{ll}{ff}" format.name$ }
               if$
             }
           if$
-          nameptr #3 = namesleft #1 > and
-            { ", " * format.et.al * }
-            'skip$
-          if$
         }
-        't
+      if$
+      nameptr #1 >
+        { ", " swap$ * * }
+        'skip$
       if$
       nameptr #1 + 'nameptr :=
       namesleft #1 - 'namesleft :=
@@ -453,8 +449,8 @@ FUNCTION {set.mark}
         { pop$ mark 'entry.mark := }
         { 'entry.mark := }
       if$
-      media empty$ not
-        { entry.mark "/" * media * 'entry.mark := }
+      medium empty$ not
+        { entry.mark "/" * medium * 'entry.mark := }
         { url empty$ not
             { entry.mark "/OL" * 'entry.mark := }
             'skip$
@@ -534,7 +530,9 @@ FUNCTION {make.full.names}
   type$ "inbook" =
   or
     'author.editor.full
-    { type$ "proceedings" =
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
         'editor.full
         'author.full
       if$
@@ -558,23 +556,15 @@ FUNCTION {output.bibitem}
   before.all 'output.state :=
 }
 
-
-FUNCTION {n.dashify}
+FUNCTION {hyphenate}
 { 't :=
   ""
     { t empty$ not }
     { t #1 #1 substring$ "-" =
-        { t #1 #2 substring$ "--" = not
-            { "--" *
-              t #2 global.max$ substring$ 't :=
-            }
-            {   { t #1 #1 substring$ "-" = }
-                { "-" *
-                  t #2 global.max$ substring$ 't :=
-                }
-              while$
-            }
-          if$
+        { "-" *
+            { t #1 #1 substring$ "-" = }
+            { t #2 global.max$ substring$ 't := }
+          while$
         }
         { t #1 #1 substring$ *
           t #2 global.max$ substring$ 't :=
@@ -920,7 +910,7 @@ FUNCTION {format.address.publisher}
 FUNCTION {format.pages}
 { pages empty$
     { "" }
-    { pages n.dashify }
+    { pages hyphenate }
   if$
 }
 
@@ -984,9 +974,9 @@ FUNCTION {format.in.ed.booktitle}
 }
 
 FUNCTION {empty.misc.check}
-{ author empty$ title empty$ howpublished empty$
-  month empty$ year empty$ note empty$
-  and and and and and
+{ author empty$ title empty$
+  year empty$
+  and and
   key empty$ not and
     { "all relevant fields are empty in " cite$ * warning$ }
     'skip$
@@ -1198,17 +1188,20 @@ FUNCTION {online}
 
 FUNCTION {misc}
 { journal empty$ not
-    { article.in.journal }
+    'article.in.journal
     { booktitle empty$ not
-        { incollection }
+        'incollection
         { url empty$ not
-            { online }
-            { monograph }
+            'online
+            { "Z" set.mark
+              monograph
+            }
           if$
         }
       if$
     }
   if$
+  empty.misc.check
 }
 
 FUNCTION {archive}
@@ -1222,7 +1215,8 @@ FUNCTION {book} { monograph }
 
 FUNCTION {collection}
 { "G" set.mark
-  monograph }
+  monograph
+}
 
 FUNCTION {database}
 { "DB" set.mark
@@ -1276,7 +1270,7 @@ FUNCTION {proceedings}
   monograph
 }
 
-FUNCTION {program}
+FUNCTION {software}
 { "CP" set.mark
   misc
 }
@@ -1365,7 +1359,7 @@ EXECUTE {init.state.consts}
 FUNCTION {set.entry.lang}
 { language empty$
     { author field.or.null title field.or.null * get.str.lang }
-    { language "english" =
+    { language "english" = language "american" = or language "british" = or
         { lang.en }
         { language "chinese" =
             { lang.zh }
@@ -1373,7 +1367,7 @@ FUNCTION {set.entry.lang}
                 { lang.ja }
                 { language "russian" =
                     { lang.ru }
-                    { lang.en }
+                    { lang.other }
                   if$
                 }
               if$
@@ -1476,10 +1470,10 @@ FUNCTION {calc.short.authors}
 { type$ "book" =
   type$ "inbook" =
   or
-  type$ "collection" =
-  or
     'author.editor.key.label
-    { type$ "proceedings" =
+    { type$ "collection" =
+      type$ "proceedings" =
+      or
         { editor empty$ not
             'editor.key.organization.label
             'author.key.organization.label
@@ -1497,7 +1491,7 @@ FUNCTION {calc.label}
   short.list
   "("
   *
-  format.year extract.before.dash duplicate$ empty$
+  format.year duplicate$ empty$
   short.list key field.or.null = or
      { pop$ "" }
      'skip$

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3079,12 +3079,12 @@
 % \subsection{参考文献}
 % \label{sec:ref}
 %
+% \changes{v5.4.4}{2018/04/12}{参考文献列表的页码使用 hyphen 取代 en dash。}
+%
 % \begin{macro}{\inlinecite}
 % 依赖于 \pkg{natbib} 宏包，修改其中的命令。 旧命令 \cs{onlinecite} 依然可用。
 % \changes{v5.0.0}{2015/11/23}{用 \cs{inlinecite} 替换 \cs{onlinecite}。为保证兼
 % 容性，\cs{onlinecite} 会保留。}
-% \changes{v5.4.0}{2017/12/3}{\cs{bibliographystyle}\marg{newbib} will cause \cs{bibstyle@newbib} to
-% be called on THE NEXT LATEX RUN (via the aux file).}
 %    \begin{macrocode}
 %<*cls>
 \newcommand\bibstyle@inline{\bibpunct{[}{]}{,}{n}{,}{,}}
@@ -3134,6 +3134,8 @@
 %    \end{macrocode}
 %
 % 两种引用样式：
+% \changes{v5.4.0}{2017/12/3}{\cs{bibliographystyle}\marg{newbib} will cause \cs{bibstyle@newbib} to
+% be called on THE NEXT LATEX RUN (via the aux file).}
 % \changes{v5.4.1}{2017/12/04}{bst 在 ctan 上不分路径，故加前缀。}
 %    \begin{macrocode}
 \expandafter\newcommand\csname bibstyle@thuthesis-numeric\endcsname{%

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3184,6 +3184,21 @@
 \renewcommand\NAT@cite%
     [3]{\ifNAT@swa\NAT@@open\if*#2*\else#2\NAT@spacechar\fi
         #1\NAT@@close\if*#3*\else\textsuperscript{#3}\fi\else#1\fi\endgroup}
+%    \end{macrocode}
+%
+% 在顺序编码制下，\pkg{natbib} 只有在三个以上连续文献引用才会使用连接号，
+% 这里修改为允许两个引用使用连接号。
+% \changes{v5.4.4}{2018/04/12}{允许连续两个文献引用使用连接号。}
+%    \begin{macrocode}
+\patchcmd{\NAT@citexnum}{%
+  \ifx\NAT@last@yr\relax
+    \def@NAT@last@yr{\@citea}%
+  \else
+    \def@NAT@last@yr{--\NAT@penalty}%
+  \fi
+}{%
+  \def@NAT@last@yr{-\NAT@penalty}%
+}{}{}
 %</cls>
 %    \end{macrocode}
 %


### PR DESCRIPTION
1. 把参考文献页码的 en dash 改为 hyphen，见 #319 。 另外我之前重写了其他部分的代码，一起 merge 过来。

2. 修正了连续两个参考文献的引用，见 https://github.com/ustctug/ustcthesis/issues/168 。

3. 解决了 latexmk 调用 xdvipdfmx 导致字体没有正确嵌入的问题，见 https://github.com/CTeX-org/ctex-kit/issues/352 。
另外更改了一点 .gitignore 和 Makefile。