### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/thuthesis-author-year.bst
+++ b/thuthesis-author-year.bst
@@ -1745,7 +1745,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$

--- a/thuthesis-numeric.bst
+++ b/thuthesis-numeric.bst
@@ -1598,7 +1598,7 @@ FUNCTION {begin.bib}
   write$ newline$
   "\providecommand{\href}[2]{\url{#2}}"
   write$ newline$
-  "\providecommand{\doi}[1]{DOI: \href{http://dx.doi.org/#1}{#1}}"
+  "\providecommand{\doi}[1]{DOI: \href{https://doi.org/#1}{#1}}"
   write$ newline$
   "\expandafter\ifx\csname urlstyle\endcsname\relax\relax\else"
   write$ newline$


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates and the commands that generate new DOI links.

Cheers!