### PR TITLE
调整字体配置（issue #341 ）

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1182,11 +1182,6 @@
 \DeclareBoolOption{tocarialchapterpage}
 %    \end{macrocode}
 %
-% 在 Windows Vista 或之后系统下时，默认使用微软雅黑，这可能会导致审查不合格。
-% 下面设置默认不使用微软雅黑，同时保持跨平台兼容性。
-%    \begin{macrocode}
-\IfFileExists{/dev/null}{}{\PassOptionsToClass{fontset=windowsold}{ctexbook}}
-%    \end{macrocode}
 %
 % \option{raggedbottom} 选项（默认打开）
 % \changes{v4.8}{2013/03/05}{增加 noraggedbottom 选项。}
@@ -1488,10 +1483,43 @@
 %
 % \subsubsection{字体}
 % \label{sec:font}
+
+% 在使用 Windows Vista 或之后版本的系统时，ctex 宏包会默认使用微软雅黑字体，
+% 这可能会导致审查不合格。
+% 下面设置适合印刷的黑体，同时保持跨平台兼容性。
+%    \begin{macrocode}
+%<*cls>
+\ExplSyntaxOn
+\str_if_eq:onT { \g__ctex_fontset_tl } { windows }
+  { \setCJKsansfont { SimHei } }
+%    \end{macrocode}
+%
+% 类似地，ctex 2.4.14 开始在 macOS 下自动调用苹方黑体，所以必进行调整。
+%    \begin{macrocode}
+\str_if_eq:onT { \g__ctex_fontset_tl } { mac }
+  {
+    \setCJKmainfont
+      [
+           UprightFont = *~Light,
+              BoldFont = *~Bold,
+            ItalicFont = Kaiti~SC,
+        BoldItalicFont = Kaiti~SC~Bold
+      ] { Songti~SC }
+    \setCJKsansfont { Heiti~SC }
+    \setCJKfamilyfont { zhsong }
+      [
+           UprightFont = *~Light,
+              BoldFont = *~Bold,
+      ] { Songti~SC }
+    \setCJKfamilyfont { zhhei } { Heiti~SC }
+    \setCJKfamilyfont { zhkai } { Kaiti~SC }
+  }
+\ExplSyntaxOff
+%    \end{macrocode}
+%
 % \begin{macro}{\normalsize}
 % 正文小四号 (12bp) 字，行距为固定值 20 bp。
 %    \begin{macrocode}
-%<*cls>
 \renewcommand\normalsize{%
   \@setfontsize\normalsize{12bp}{20bp}%
   \abovedisplayskip=20bp \@plus 2bp \@minus 2bp

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1491,7 +1491,14 @@
 %<*cls>
 \ExplSyntaxOn
 \str_if_eq:onT { \g__ctex_fontset_tl } { windows }
-  { \setCJKsansfont { SimHei } }
+  {
+    \sys_if_engine_pdftex:TF
+      {
+        \setCJKsansfont { simhei.ttf }
+        \ctex_punct_map_family:nn { \CJKsfdefault } { zhhei }
+      }
+      { \setCJKsansfont { SimHei } }
+  }
 %    \end{macrocode}
 %
 % 类似地，ctex 2.4.14 开始在 macOS 下自动调用苹方黑体，所以必进行调整。

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1489,39 +1489,34 @@
 % 下面设置适合印刷的黑体，同时保持跨平台兼容性。
 %    \begin{macrocode}
 %<*cls>
-\ExplSyntaxOn
-\str_if_eq:onT { \g__ctex_fontset_tl } { windows }
-  {
-    \sys_if_engine_pdftex:TF
-      {
-        \setCJKsansfont { simhei.ttf }
-        \ctex_punct_map_family:nn { \CJKsfdefault } { zhhei }
-      }
-      { \setCJKsansfont { SimHei } }
-  }
+\newcommand\thu@fontset{\csname g__ctex_fontset_tl\endcsname}
+\ifthenelse{\equal{\thu@fontset}{windows}}{
+  \ifxetex
+    \setCJKsansfont{SimHei}
+  \else
+    \setCJKsansfont{simhei.ttf}
+    \csname ctex_punct_map_family:nn\endcsname{\CJKsfdefault}{zhhei}
+  \fi
+}{}
 %    \end{macrocode}
 %
 % 类似地，ctex 2.4.14 开始在 macOS 下自动调用苹方黑体，所以必进行调整。
 %    \begin{macrocode}
-\str_if_eq:onT { \g__ctex_fontset_tl } { mac }
-  {
-    \setCJKmainfont
-      [
-           UprightFont = *~Light,
-              BoldFont = *~Bold,
-            ItalicFont = Kaiti~SC,
-        BoldItalicFont = Kaiti~SC~Bold
-      ] { Songti~SC }
-    \setCJKsansfont { Heiti~SC }
-    \setCJKfamilyfont { zhsong }
-      [
-           UprightFont = *~Light,
-              BoldFont = *~Bold,
-      ] { Songti~SC }
-    \setCJKfamilyfont { zhhei } { Heiti~SC }
-    \setCJKfamilyfont { zhkai } { Kaiti~SC }
-  }
-\ExplSyntaxOff
+\ifthenelse{\equal{\thu@fontset}{mac}}{
+  \setCJKmainfont[
+         UprightFont = * Light,
+            BoldFont = * Bold,
+          ItalicFont = Kaiti SC,
+      BoldItalicFont = Kaiti SC Bold
+    ]{Songti SC}
+  \setCJKsansfont{Heiti SC}
+  \setCJKfamilyfont{zhsong}[
+         UprightFont = * Light,
+            BoldFont = * Bold,
+    ]{Songti SC}
+  \setCJKfamilyfont{zhhei}{Heiti SC}
+  \setCJKfamilyfont{zhkai}{Kaiti SC}
+}{}
 %    \end{macrocode}
 %
 % \begin{macro}{\normalsize}


### PR DESCRIPTION
close #341 

- 正确配置 windows 的字体，取消使用微软雅黑，并且解决 Kati-gb2312 和 Fangsong-gb2312 缺失的问题
- 取消 ctex 2.4.14 在 macOS 下默认设置的苹方黑体
- 调整在 macOS 下的字体配置，允许使用更多字重