### PR TITLE
use unicode-math to load math fonts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-os:
-  - linux
-
-sudo: required
+language: generic
 
 install:
   - REMOTE="http://mirror.ctan.org/systems/texlive/tlnet"
@@ -10,28 +7,30 @@ install:
   - curl -sSL $REMOTE/install-tl-unx.tar.gz | tar -xzv -C $INSTALL --strip-components=1
 
   - echo "selected_scheme scheme-basic" >> $INSTALL/tl.profile
-  - echo "collection-basic 1" >> $INSTALL/tl.profile
-  - echo "collection-fontsrecommended 1" >> $INSTALL/tl.profile
-  - echo "collection-langchinese 1" >> $INSTALL/tl.profile
-  - echo "collection-latex 1" >> $INSTALL/tl.profile
-  - echo "collection-latexextra 1" >> $INSTALL/tl.profile
-  - echo "collection-latexrecommended 1" >> $INSTALL/tl.profile
-  - echo "collection-xetex 1" >> $INSTALL/tl.profile
+  - echo "TEXDIR /tmp/texlive" >> $INSTALL/tl.profile
+  - echo "TEXMFLOCAL /tmp/texlive/texmf-local" >> $INSTALL/tl.profile
+  - echo "TEXMFSYSCONFIG /tmp/texlive/texmf-config" >> $INSTALL/tl.profile
+  - echo "TEXMFSYSVAR /tmp/texlive/texmf-var" >> $INSTALL/tl.profile
   - echo "tlpdbopt_autobackup 0" >> $INSTALL/tl.profile
   - echo "tlpdbopt_install_docfiles 0" >> $INSTALL/tl.profile
   - echo "tlpdbopt_install_srcfiles 0" >> $INSTALL/tl.profile
 
-  - sudo $INSTALL/install-tl -profile $INSTALL/tl.profile
-
-  - VERSION=$($INSTALL/install-tl --version | grep 'version' | grep -o '[0-9]\{4\}')
+  - $INSTALL/install-tl -profile $INSTALL/tl.profile
   - PLATFORM=$($INSTALL/install-tl --print-platform)
-  - TEXBIN="/usr/local/texlive/${VERSION}/bin/${PLATFORM}"
-  - export "PATH=$TEXBIN:$PATH"
+  - export PATH="/tmp/texlive/bin/$PLATFORM:$PATH"
 
-  - sudo $TEXBIN/tlmgr install boondox latexmk ulem newpx newtx
+
+
+  - tlmgr install latexmk
+    fandol tex-gyre stix2-otf xits
+    fontspec l3kernel l3packages xetex
+    cjk ctex environ ms trimspaces ulem xecjk zhnumber
+    booktabs caption diagbox enumitem eso-pic etoolbox filehook float footmisc
+    fp multirow notoccite ntheorem pdfpages pict2e unicode-math xcolor zapfding
+    fontaxes kastrup listings lm metalogo newtx newpx palatino pxfonts thumbpdf
+    txfonts xkeyval
 
 before_script:
-  - sed -i 's/degree=bachelor/degree=doctor/' main.tex
   - sed -i 's/\[RawFeature={vertical:}\]{FangSong}/\[Extension=.otf,RawFeature={vertical:}\]{FandolFang-Regular}/' shuji.tex
 
 script:

--- a/data/appendix01.tex
+++ b/data/appendix01.tex
@@ -31,13 +31,14 @@ as follows,
 which maximizes a real-valued function $f$ of
 $x=(x_1,x_2,\cdots,x_n)$ subject to a set of constraints.
 
+\newcommand\Real{\mathbf{R}}
 \newtheorem{mpdef}{Definition}[chapter]
 \begin{mpdef}
 In SOP, we call $x$ a decision vector, and
 $x_1,x_2,\cdots,x_n$ decision variables. The function
 $f$ is called the objective function. The set
 \begin{equation}\tag*{(456)} % 这里同理，其它不再一一指定。
-S=\left\{x\in\Re^n\bigm|g_j(x)\le 0,\,j=1,2,\cdots,p\right\}
+S=\left\{x\in\Real^n\bigm|g_j(x)\le 0,\,j=1,2,\cdots,p\right\}
 \end{equation}
 is called the feasible set. An element $x$ in $S$ is called a
 feasible solution.
@@ -134,8 +135,8 @@ concerned with analyzing the structure of problems.
 \end{figure}
 
 Now we consider a nonlinear programming which is confronted solely with
-maximizing a real-valued function with domain $\Re^n$.  Whether derivatives are
-available or not, the usual strategy is first to select a point in $\Re^n$ which
+maximizing a real-valued function with domain $\Real^n$.  Whether derivatives are
+available or not, the usual strategy is first to select a point in $\Real^n$ which
 is thought to be the most likely place where the maximum exists. If there is no
 information available on which to base such a selection, a point is chosen at
 random. From this first point an attempt is made to construct a sequence of

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -13,7 +13,7 @@
 
 
 \section{封面相关}
-封面的例子请参看 \texttt{cover.tex}。主要符号表参看 \texttt{denation.tex}，附录和
+封面的例子请参看 \texttt{cover.tex}。主要符号表参看 \texttt{denotation.tex}，附录和
 个人简历分别参看 \texttt{appendix01.tex} 和 \texttt{resume.tex}。里面的命令都很直
 观，一看即会\footnote{你说还是看不懂？怎么会呢？}。
 

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -63,7 +63,7 @@
   离；离者丽也。}
 
 \section{表格样本}
-\label{chap1:sample:table} 
+\label{chap1:sample:table}
 
 \subsection{基本表格}
 \label{sec:basictable}
@@ -108,7 +108,7 @@
   \centering
   \caption{复杂表格示例 1。这个引用 \cite{tex} 不会导致编号混乱。}
   \label{tab:tabexamp1}
-  \begin{minipage}[t]{0.8\textwidth} 
+  \begin{minipage}[t]{0.8\textwidth}
     \begin{tabularx}{\linewidth}{|l|X|X|X|X|}
       \hline
       \multirow{2}*{\diagbox[width=5em]{x}{y}} & \multicolumn{2}{c|}{First Half} & \multicolumn{2}{c|}{Second Half}\\\cline{2-5}
@@ -214,7 +214,7 @@
   \caption{复杂表格示例 2}
   \label{tab:tabexamp2}
   \begin{tabular}[c]{|m{1.5cm}|c|c|c|c|c|c|}\hline
-    \multicolumn{2}{|c|}{Network Topology} & \# of nodes & 
+    \multicolumn{2}{|c|}{Network Topology} & \# of nodes &
     \multicolumn{3}{c|}{\# of clients} & Server \\\hline
     GT-ITM & Waxman Transit-Stub & 600 &
     \multirow{2}{1em}{2\%}&
@@ -375,7 +375,7 @@ EP.B.8 & 126.74 & 0.003 & 0.017 & 0.005 & 0.083 & 1656 \\
 \begin{remark}
 天不言自高，水不言自流。
 \begin{gather*}
-\begin{split} 
+\begin{split}
 \varphi(x,z)
 &=z-\gamma_{10}x-\gamma_{mn}x^mz^n\\
 &=z-Mr^{-1}x-Mr^{-(m+n)}x^mz^n
@@ -394,7 +394,7 @@ EP.B.8 & 126.74 & 0.003 & 0.017 & 0.005 & 0.083 & 1656 \\
 业。易简，而天下矣之理矣；天下之理得，而成位乎其中矣。
 
 \begin{axiom}
-两点间直线段距离最短。  
+两点间直线段距离最短。
 \begin{align}
 x&\equiv y+1\pmod{m^2}\\
 x&\equiv y+1\mod{m^2}\\
@@ -409,13 +409,14 @@ x&\equiv y+1\pod{m^2}
 乾，反复道也。或跃在渊，进无咎也。飞龙在天，大人造也。亢龙有悔，盈不可久也。用九，
 天德不可为首也。 　　
 
+\newcommand\dif{\mathop{}\!\mathrm{d}}
 \begin{lemma}
 《猫和老鼠》是我最爱看的动画片。
 \begin{multline*}%\tag*{[a]} % 这个不出现在索引中
 \int_a^b\biggl\{\int_a^b[f(x)^2g(y)^2+f(y)^2g(x)^2]
- -2f(x)g(x)f(y)g(y)\,dx\biggr\}\,dy \\
+ -2f(x)g(x)f(y)g(y)\dif x\biggr\}\dif y \\
  =\int_a^b\biggl\{g(y)^2\int_a^bf^2+f(y)^2
-  \int_a^b g^2-2f(y)g(y)\int_a^b fg\biggr\}\,dy
+  \int_a^b g^2-2f(y)g(y)\int_a^b fg\biggr\}\dif y
 \end{multline*}
 \end{lemma}
 
@@ -488,7 +489,7 @@ V_j & = v_j, & \qquad X_j & = x_j,
 \end{conjecture}
 
 \begin{problem}
- 回答还是不回答，是个问题。 
+ 回答还是不回答，是个问题。
 \end{problem}
 
 如何引用定理~\ref{the:theorem1} 呢？加上 \cs{label} 使用 \cs{ref} 即可。妾发
@@ -530,29 +531,31 @@ V_j & = v_j, & \qquad X_j & = x_j,
 
 \section{公式}
 \label{sec:equation}
-贝叶斯公式如式~(\ref{equ:chap1:bayes})，其中 $p(y|\mathbf{x})$ 为后验；
-$p(\mathbf{x})$ 为先验；分母 $p(\mathbf{x})$ 为归一化因子。
+\renewcommand\vec{\symbf}
+\newcommand\mat{\symbf}
+贝叶斯公式如式~(\ref{equ:chap1:bayes})，其中 $p(y|\vec{x})$ 为后验；
+$p(\vec{x})$ 为先验；分母 $p(\vec{x})$ 为归一化因子。
 \begin{equation}
 \label{equ:chap1:bayes}
-p(y|\mathbf{x}) = \frac{p(\mathbf{x},y)}{p(\mathbf{x})}=
-\frac{p(\mathbf{x}|y)p(y)}{p(\mathbf{x})} 
+p(y|\vec{x}) = \frac{p(\vec{x},y)}{p(\vec{x})}=
+\frac{p(\vec{x}|y)p(y)}{p(\vec{x})}
 \end{equation}
 
 论文里面公式越多，\TeX{} 就越 happy。再看一个 \pkg{amsmath} 的例子：
-\newcommand{\envert}[1]{\left\lvert#1\right\rvert} 
+\newcommand{\envert}[1]{\left\lvert#1\right\rvert}
 \begin{equation}\label{detK2}
-\det\mathbf{K}(t=1,t_1,\dots,t_n)=\sum_{I\in\mathbf{n}}(-1)^{\envert{I}}
-\prod_{i\in I}t_i\prod_{j\in I}(D_j+\lambda_jt_j)\det\mathbf{A}
+\det\mat{K}(t=1,t_1,\dots,t_n)=\sum_{I\in\vec{n}}(-1)^{\envert{I}}
+\prod_{i\in I}t_i\prod_{j\in I}(D_j+\lambda_jt_j)\det\vec{A}
 ^{(\lambda)}(\overline{I}|\overline{I})=0.
-\end{equation} 
+\end{equation}
 
 前面定理示例部分列举了很多公式环境，可以说把常见的情况都覆盖了，大家在写公式的时
 候一定要好好看 \pkg{amsmath} 的文档，并参考模板中的用法：
 \begin{multline*}%\tag{[b]} % 这个出现在索引中的
 \int_a^b\biggl\{\int_a^b[f(x)^2g(y)^2+f(y)^2g(x)^2]
- -2f(x)g(x)f(y)g(y)\,dx\biggr\}\,dy \\
+ -2f(x)g(x)f(y)g(y)\dif x\biggr\}\dif y \\
  =\int_a^b\biggl\{g(y)^2\int_a^bf^2+f(y)^2
-  \int_a^b g^2-2f(y)g(y)\int_a^b fg\biggr\}\,dy
+  \int_a^b g^2-2f(y)g(y)\int_a^b fg\biggr\}\dif y
 \end{multline*}
 
 其实还可以看看这个多级规划：

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -344,11 +344,11 @@ EP.B.8 & 126.74 & 0.003 & 0.017 & 0.005 & 0.083 & 1656 \\
 
 \begin{assumption}
 待月西厢下，迎风户半开；隔墙花影动，疑是玉人来。
-\begin{eqnarray}
+\begin{align}
   \label{eq:eqnxmp}
-  c & = & a^2 - b^2\\
-    & = & (a+b)(a-b)
-\end{eqnarray}
+  c & = a^2 - b^2 \\
+    & = (a+b)(a-b)
+\end{align}
 \end{assumption}
 
 千辛万苦，历尽艰难，得有今日。然相从数千里，未曾哀戚。今将渡江，方图百年欢笑，如

--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -8,8 +8,8 @@
 习一下：
 \begin{equation}
 \label{equ:chap2:bayes}
-p(y|\mathbf{x}) = \frac{p(\mathbf{x},y)}{p(\mathbf{x})}=
-\frac{p(\mathbf{x}|y)p(y)}{p(\mathbf{x})}
+p(y|\vec{x}) = \frac{p(\vec{x},y)}{p(\vec{x})}=
+\frac{p(\vec{x}|y)p(y)}{p(\vec{x})}
 \end{equation}
 
 \subsection{绘图}

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1811,7 +1811,6 @@
 % \begin{macro}{\leq}
 % \begin{macro}{\geq}
 % 小于等于号要使用倾斜的形式。
-% \changes{v3.0}{2017/07/01}{更正了 LaTeX 的小于等于号}
 %    \begin{macrocode}
 \protected\def\le{\leqslant}
 \protected\def\ge{\geqslant}

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1226,13 +1226,6 @@
 \fi
 %    \end{macrocode}
 %
-% 使用 \XeTeX\ 引擎时，\pkg{fontspec} 宏包会被 \pkg{xeCJK} 自动调用。传递
-% 给 \pkg{fontspec} 宏包 \option{no-math} 选项，避免部分数学符号字体自动调整
-% 为 CMR。其他引擎下没有这个问题，这一行会被无视。
-%    \begin{macrocode}
-\PassOptionsToPackage{no-math}{fontspec}
-%    \end{macrocode}
-%
 % \changes{v5.3.1}{2016/03/20}{使用 \CTeX\ 默认中文字体配置，支持不同引擎。}
 % 使用 \pkg{ctexbook} 类，优于调用 \pkg{ctex} 宏包。
 %    \begin{macrocode}
@@ -1256,21 +1249,13 @@
 \RequirePackage{amsmath}
 %    \end{macrocode}
 %
-% \pkg{newtx} 设置 Times New Roman，Helvetica。
+% 使用 \pkg{unicode-math} 处理数学字体。
 % \changes{v3.1}{2007/06/16}{replace \pkg{mathptmx} with \pkg{txfonts}.}
 % \changes{v5.2.1}{2016/01/14}{使用 \pkg{newtx} 替换 \pkg{txfonts}。}
 % \changes{v5.2.2}{2016/02/01}{不希望 \pkg{newtx} 修改 \cs{@makefnmark}。 }
+% \changes{v5.5}{2018/07/07}{使用 \pkg{unicode-math} 处理数学字体。}
 %    \begin{macrocode}
-\RequirePackage[defaultsups]{newtxtext}
-\RequirePackage{newtxmath}
-%    \end{macrocode}
-%
-% \pkg{newtx} 的 Mono 字体虽然很好看，但在论文中不常见。学校虽未要求 Mono 字体，
-% 还是选择常见的 Courier 字体。由于比较新的实现 \TeX\ Gyre Cursor 会修
-% 改\cs{bfdefault}，导致中文加粗出问题，所以选用标准 \pkg{courier}。
-% \changes{v5.3.2}{2016/5/24}{替换 \pkg{tgcursor} 为 \pkg{courier}。}
-%    \begin{macrocode}
-\RequirePackage{courier}
+\RequirePackage{unicode-math}
 %    \end{macrocode}
 %
 % 图形支持宏包。
@@ -1494,11 +1479,70 @@
 %
 % \subsubsection{字体}
 % \label{sec:font}
-% 在使用 Windows Vista 或之后版本的系统时，\pkg{ctex} 宏包会默认使用微软雅黑字体，
-% 这可能会导致审查不合格。 下面设置适合印刷的黑体，同时保持跨平台兼容性。
+% 使用 \pkg{fontspec} 配置字体。
 %    \begin{macrocode}
 %<*cls>
 \newcommand\thu@fontset{\csname g__ctex_fontset_tl\endcsname}
+\ifthenelse{\equal{\thu@fontset}{fandol}}{
+  \setmainfont[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+  ]{texgyretermes}
+  \setsansfont[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+    Scale          = MatchLowercase,
+  ]{texgyreheros}
+  \setmonofont[
+    Extension      = .otf,
+    UprightFont    = *-regular,
+    BoldFont       = *-bold,
+    ItalicFont     = *-italic,
+    BoldItalicFont = *-bolditalic,
+    Scale          = MatchLowercase,
+  ]{texgyrecursor}
+}{
+  \setmainfont{Times New Roman}
+  \setsansfont[Scale=MatchLowercase]{Arial}
+  \ifthenelse{\equal{\thu@fontset}{mac}}{
+    \setmonofont[Scale=MatchLowercase]{Menlo}
+  }{
+    \setmonofont[Scale=MatchLowercase]{Courier}
+  }
+}
+%    \end{macrocode}
+%
+% 使用 \pkg{unicode-math} 配置数学字体
+%    \begin{macrocode}
+\unimathsetup{
+  math-style = ISO,
+  bold-style = ISO,
+  nabla      = upright,
+  partial    = upright,
+}
+\IfFontExistsTF{STIX2Math.otf}{
+  \setmathfont[StylisticSet={2,8}]{STIX2Math.otf}
+  \setmathfont[range={scr,bfscr},StylisticSet=1]{STIX2Math.otf}
+  \setmathfont[range=\partial]{xits-math.otf}
+}{
+  \setmathfont[
+    Extension    = .otf,
+    BoldFont     = *bold,
+    StylisticSet = 8,
+  ]{xits-math}
+  \setmathfont[range={cal,bfcal},StylisticSet=1]{xits-math.otf}
+}
+%    \end{macrocode}
+%
+% 在使用 Windows Vista 或之后版本的系统时，\pkg{ctex} 宏包会默认使用微软雅黑字体，
+% 这可能会导致审查不合格。下面设置适合印刷的黑体，同时保持跨平台兼容性。
+%    \begin{macrocode}
 \ifthenelse{\equal{\thu@fontset}{windows}}{
   \ifxetex
     \setCJKsansfont{SimHei}
@@ -1754,9 +1798,68 @@
 %
 % \subsubsection{数学相关}
 % \label{sec:equation}
-% 允许太长的公式断行、分页等。
+% \begin{macro}{\ldots}
+% 省略号一律居中，所以 \cs{ldots} 不再居于底部。
 %    \begin{macrocode}
 %<*cls>
+\def\mathellipsis{\cdots}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\le}
+% \begin{macro}{\ge}
+% \begin{macro}{\leq}
+% \begin{macro}{\geq}
+% 小于等于号要使用倾斜的形式。
+% \changes{v3.0}{2017/07/01}{更正了 LaTeX 的小于等于号}
+%    \begin{macrocode}
+\protected\def\le{\leqslant}
+\protected\def\ge{\geqslant}
+\AtBeginDocument{%
+  \renewcommand\leq{\leqslant}%
+  \renewcommand\geq{\geqslant}%
+}
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\int}
+% 积分号 \cs{int} 使用正体，并且上下限默认置于积分号上下两侧。
+%    \begin{macrocode}
+% \removenolimits{%
+%   \int\iint\iiint\iiiint\oint\oiint\oiiint
+%   \intclockwise\varointclockwise\ointctrclockwise\sumint
+%   \intbar\intBar\fint\cirfnint\awint\rppolint
+%   \scpolint\npolint\pointint\sqint\intlarhk\intx
+%   \intcap\intcup\upint\lowint
+% }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\nabla}
+% \cs{nabla} 使用粗正体。
+%    \begin{macrocode}
+\AtBeginDocument{%
+  \renewcommand\nabla{\mbfnabla}%
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\bm}
+% \begin{macro}{\boldsymbol}
+% 兼容旧的粗体命令：\pkg{bm} 的 \cs{bm} 和 \pkg{amsmath} 的 \cs{boldsymbol}。
+%    \begin{macrocode}
+\newcommand\bm{\symbf}
+\renewcommand\boldsymbol{\symbf}
+\newcommand\square{\mdlgblksquare}
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% 允许太长的公式断行、分页等。
+%    \begin{macrocode}
 \allowdisplaybreaks[4]
 \renewcommand\theequation{\ifnum \c@chapter>\z@ \thechapter-\fi\@arabic\c@equation}
 %    \end{macrocode}


### PR DESCRIPTION
1. 正文字体使用 fontspec 配置 Times New Roman 和 Arial
2. 数学字体使用 `unicode-math` 配置 STIX2
2. 调整数学符号满足 GB 3102.11-1993 