### PR TITLE
add comments on additional formatting that some departments require

### DIFF
--- a/data/appendix01.tex
+++ b/data/appendix01.tex
@@ -1,6 +1,18 @@
 \chapter{外文资料原文}
 \label{cha:engorg}
 
+% 部分院系要求附录的内部章节不列入目录，但这些章节仍需要编号。
+% 仅使用\section*{}命令无法完成编号，为此可采用以下组合命令：
+% \newcommand{\hiddensection}[1]{
+%   \stepcounter{section}
+%   \section*{\Alph{chapter}.\arabic{section}\hspace{1em}{#1}}
+% }
+% \newcommand{\hiddensubsection}[1]{
+%   \stepcounter{subsection}
+%   \subsection*{\Alph{chapter}.\arabic{section}.\arabic{subsection}\hspace{1em}{#1}}
+% }
+% 这样，采用\hiddensection{}命令就能给章节编号但又不列入目录。
+
 \title{The title of the English paper}
 
 \textbf{Abstract:} As one of the most widely used techniques in operations

--- a/data/cover.tex
+++ b/data/cover.tex
@@ -19,7 +19,7 @@
   cdepartment={计算机科学与技术系},
   cmajor={计算机科学与技术},
   cauthor={薛瑞尼},
-  csupervisor={郑纬民教授},
+  csupervisor={郑纬民教授}, % 部分院系要求在老师名字与称呼之间空一个字，例如：{郑纬民\quad 教授}
   cassosupervisor={陈文光教授}, % 副指导老师
   ccosupervisor={某某某教授}, % 联合指导老师
   % 日期自动使用当前时间，若需指定按如下方式修改：


### PR DESCRIPTION
部分院系（例如自动化系）有额外的格式要求，例如指导教师的名字与称谓间加入空格、附录内的章节标题不列入目录等。我在正文的相应位置增加了注释，给出相应写法以供参考。

Some departments like Dept. of Automation have additional formatting requirements, including white space added between professor names and titles, sections in appendix not listed in table of contents, etc. I added comments in corresponding lines to explain and provide possible workarounds. 