### PR TITLE
Enable marginpar in geometry setup

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -1284,7 +1284,8 @@
 \RequirePackage{geometry}
 \geometry{
   a4paper, % 210 * 297mm
-  nomarginpar,
+  marginparwidth = 2cm,
+  marginparsep = 0.5cm
 }
 \ifthu@degree@bachelor
   \geometry{


### PR DESCRIPTION
这样允许用户正常使用 `todonotes` 等宏包。经过观察没有产生副作用。

Signed-off-by: Harry Chen <i@harrychen.xyz>