### PR TITLE
Set pdflang after hyperref is loaded, fix #482

### DIFF
--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3430,6 +3430,15 @@
   \@ifpackagelater{hyperref}{2019/04/27}{}{%
     \g@addto@macro\psdmapshortnames{\let\mu\textmu}
   }%
+  \ifthu@language@chinese
+    \hypersetup{
+      pdflang = zh-CN,
+    }%
+  \else
+    \hypersetup{
+      pdflang = en-US,
+    }%
+  \fi
   \AtBeginDocument{%
     \ifthu@language@chinese
       \hypersetup{
@@ -3437,7 +3446,6 @@
         pdfauthor   = \thu@author,
         pdfsubject  = \thu@degree@name,
         pdfkeywords = \thu@keywords,
-        pdflang     = zh-CN,
       }%
     \else
       \hypersetup{
@@ -3445,7 +3453,6 @@
         pdfauthor   = \thu@author@en,
         pdfsubject  = \thu@degree@name@en,
         pdfkeywords = \thu@keywords@en,
-        pdflang     = en-US,
       }%
     \fi
     \hypersetup{


### PR DESCRIPTION
RT. 不知道是哪个宏包设置了 `pdflang`，导致现在的用法是无效的。在 `hyperref` 被加载的时候先设置上，就不会有问题。

Signed-off-by: Harry Chen <i@harrychen.xyz>