### PR TITLE
Flexible list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Added
 - 允许使用边注
 - 新增 `amsthm` 支持
+- 支持单个关键词设置样式
 
 ## Changed
 - 附录的图、表不再加入索引

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "fancy-log": "^1.3.3",
     "gulp": "^4.0.2",
     "gulp-zip": "^5.0.1",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.5"
   },
   "dependencies": {}
 }

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3051,7 +3051,7 @@
     \fi
     ##1%
   }%
-  \comma@parse{#1}{\thu@clist@processor}%
+  \expandafter\comma@parse\expandafter{#1}{\thu@clist@processor}%
 }
 %    \end{macrocode}
 % \end{macro}

--- a/thuthesis.dtx
+++ b/thuthesis.dtx
@@ -3043,7 +3043,7 @@
 }
 \newcommand\thu@clist@use[2]{%
   \def\thu@@tmp{}%
-  \kv@set@family@handler{thu@clist}{%
+  \def\thu@clist@processor##1{%
     \ifx\thu@@tmp\@empty
       \def\thu@@tmp{#2}%
     \else
@@ -3051,7 +3051,7 @@
     \fi
     ##1%
   }%
-  \kvsetkeys@expandafter{thu@clist}{#1}%
+  \comma@parse{#1}{\thu@clist@processor}%
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
有人写信问
![image](https://user-images.githubusercontent.com/1863/78766051-5fb89900-79bb-11ea-8315-cc619b6cf0ff.png)


# Example
```diff
diff --git a/data/abstract.tex b/data/abstract.tex
index a7737b5..8921e3b 100644
--- a/data/abstract.tex
+++ b/data/abstract.tex
@@ -27,7 +27,7 @@

   % 关键词用“英文逗号”分隔
   \thusetup{
-    keywords = {TeX, LaTeX, CJK, 模板, 论文},
+    keywords = {TeX, \textbf{LaTeX}, CJK, 模板, 论文},
   }
 \end{abstract}

@@ -50,6 +50,6 @@
   information of the dissertation. An abstract may contain a maximum of 5 key
   words, with semi-colons used in between to separate one another.
   \thusetup{
-    keywords* = {TeX, LaTeX, CJK, template, thesis},
+    keywords* = {TeX, LaTeX, CJK, \textit{template}, thesis},
   }
 \end{abstract*}
```

显示效果：

![image](https://user-images.githubusercontent.com/1863/78765733-fa64a800-79ba-11ea-8e00-13593ad3c1a8.png)
![image](https://user-images.githubusercontent.com/1863/78765743-ffc1f280-79ba-11ea-994f-3daa1b77f809.png)
